### PR TITLE
Task_73. Добавить бизнес логику для неправильного ответа на экзамене

### DIFF
--- a/PDD.NET.Client/pdd-net-client/src/components/category-questions-layout.tsx
+++ b/PDD.NET.Client/pdd-net-client/src/components/category-questions-layout.tsx
@@ -38,7 +38,10 @@ const CategoryQuestionsLayout: React.FC = () => {
       {error && <h1 className="display-4 mb-4">Ошибка: {error}</h1>}
       {currentQuestions.length > 0 ? (
         <>
-          <QuestionNumberList questions={currentQuestions} />
+          <QuestionNumberList
+            questions={currentQuestions}
+            initNumberQuestion={0}
+          />
           <Routes>
             <Route path=":questionId" element={<QuestionCard />} />
           </Routes>

--- a/PDD.NET.Client/pdd-net-client/src/components/question-number-list.tsx
+++ b/PDD.NET.Client/pdd-net-client/src/components/question-number-list.tsx
@@ -5,7 +5,10 @@ import Container from "react-bootstrap/Container";
 import Nav from "react-bootstrap/Nav";
 import CustomNavLink from "./custom-nav-link/custom-nav-link";
 
-const QuestionNumberList: React.FC<IQuestionList> = ({ questions }) => {
+const QuestionNumberList: React.FC<IQuestionList> = ({
+  questions,
+  initNumberQuestion,
+}) => {
   return (
     <>
       {questions && questions.length > 0 && (
@@ -21,7 +24,7 @@ const QuestionNumberList: React.FC<IQuestionList> = ({ questions }) => {
                       to={`${item.id}`}
                       key={item.id}
                     >
-                      {index + 1}
+                      {initNumberQuestion + index + 1}
                     </Nav.Link>
                   ))}
                 </Nav>

--- a/PDD.NET.Client/pdd-net-client/src/pages/exam-page.tsx
+++ b/PDD.NET.Client/pdd-net-client/src/pages/exam-page.tsx
@@ -18,6 +18,7 @@ import {
 } from "../services/exam-history/selectors";
 import { resetExamHistoryState } from "../services/exam-history/reducer";
 import { createExamHistory } from "../services/exam-history/actions";
+import { getUser } from "../services/auth/selectors";
 
 const ExamPage: React.FC = () => {
   const dispatch = useAppDispatch();
@@ -85,10 +86,22 @@ const ExamPage: React.FC = () => {
 
   const isCreateLoading = useAppSelector(getCreateExamHistoryLoading);
   const createError = useAppSelector(getCreateExamHistoryError);
+  const currentUser = useAppSelector(getUser);
+
+  const isSuccess = useMemo(() => {
+    return (
+      (wrongAnswersCount === 0 && rightAnswersCount === 20) ||
+      (wrongAnswersCount === 1 && rightAnswersCount === 24) ||
+      (wrongAnswersCount === 2 && rightAnswersCount === 28)
+    );
+  }, [wrongAnswersCount, rightAnswersCount]);
 
   const onFinishHandleClick = () => {
-    // TODO: Пока для теста - исправить
-    dispatch(createExamHistory({ userId: 1, isSuccess: true }));
+    if (currentUser && currentUser.id) {
+      dispatch(
+        createExamHistory({ userId: currentUser.id, isSuccess: isSuccess }),
+      );
+    }
     setIsStart(false);
     setIsShowResults(true);
   };
@@ -119,6 +132,7 @@ const ExamPage: React.FC = () => {
           {isShowResults && (
             <>
               <h4 className="display-8 mt-4">Экзамен завершен!</h4>
+              <div>Результат: {isSuccess ? "Успех" : "Неудача"}</div>
               <div>Правильных ответов: {rightAnswersCount}</div>
               <div>Неправильных ответов: {wrongAnswersCount}</div>
             </>

--- a/PDD.NET.Client/pdd-net-client/src/pages/exam-page.tsx
+++ b/PDD.NET.Client/pdd-net-client/src/pages/exam-page.tsx
@@ -54,6 +54,7 @@ const ExamPage: React.FC = () => {
   const [isStart, setIsStart] = useState<boolean>(false);
   const [timeLeft, setTimeLeft] = useState<number>(initTimeLeft);
   const hasFinished = useRef(false);
+  const [isShowResults, setIsShowResults] = useState<boolean>(false);
 
   useEffect(() => {
     let timer: NodeJS.Timeout;
@@ -73,6 +74,7 @@ const ExamPage: React.FC = () => {
   }, [isStart, timeLeft]);
 
   const onStartHandleClick = () => {
+    setIsShowResults(false);
     dispatch(resetExamHistoryState());
     dispatch(resetCurrentAnswers());
 
@@ -88,9 +90,7 @@ const ExamPage: React.FC = () => {
     // TODO: Пока для теста - исправить
     dispatch(createExamHistory({ userId: 1, isSuccess: true }));
     setIsStart(false);
-    alert(
-      `Экзамен завершен!\nПравильных ответов: ${rightAnswersCount} из ${currentQuestions.length}`,
-    );
+    setIsShowResults(true);
   };
 
   const formatTime = (seconds: number) => {
@@ -116,6 +116,13 @@ const ExamPage: React.FC = () => {
             Начать экзамен
           </Button>
           <div>После нажатия на кнопку "Начать экзамен", пойдет таймер.</div>
+          {isShowResults && (
+            <>
+              <h4 className="display-8 mt-4">Экзамен завершен!</h4>
+              <div>Правильных ответов: {rightAnswersCount}</div>
+              <div>Неправильных ответов: {wrongAnswersCount}</div>
+            </>
+          )}
         </>
       ) : (
         <>

--- a/PDD.NET.Client/pdd-net-client/src/types/types.tsx
+++ b/PDD.NET.Client/pdd-net-client/src/types/types.tsx
@@ -94,6 +94,7 @@ export interface IAnswer {
 
 export interface IQuestionList {
   questions: Array<IQuestion>;
+  initNumberQuestion: number;
 }
 
 export interface IIconProps {

--- a/PDD.NET.Client/pdd-net-client/src/utils/questions-api.tsx
+++ b/PDD.NET.Client/pdd-net-client/src/utils/questions-api.tsx
@@ -21,7 +21,7 @@ export const getQuestionsByCategory = async (
 };
 
 export const getExamQuestions = async (): Promise<IQuestion[]> => {
-  const res = await fetch(`${baseApiConfig.baseUrl}/questions`, {
+  const res = await fetch(`${baseApiConfig.baseUrl}/questions/exam`, {
     method: "GET",
     headers: baseApiConfig.headers,
   });

--- a/PDD.NET_Api/PDD.NET.QuestionAnswer/PDD.NET.Application/Features/Questions/Queries/GetExamQuestions/GetExamQuestionsHandler.cs
+++ b/PDD.NET_Api/PDD.NET.QuestionAnswer/PDD.NET.Application/Features/Questions/Queries/GetExamQuestions/GetExamQuestionsHandler.cs
@@ -1,0 +1,30 @@
+using AutoMapper;
+using MediatR;
+using PDD.NET.Application.Features.Questions.Queries.GetAllQuestions;
+using PDD.NET.Application.Repositories;
+
+namespace PDD.NET.Application.Features.Questions.Queries.GetExamQuestions;
+
+public sealed class GetExamQuestionsHandler : IRequestHandler<GetExamQuestionsRequest, IEnumerable<GetAllQuestionResponse>>
+{
+    private readonly IQuestionRepository _questionRepository;
+    private readonly IMapper _mapper;
+
+    public GetExamQuestionsHandler(IQuestionRepository questionRepository, IMapper mapper)
+    {
+        _questionRepository = questionRepository;
+        _mapper = mapper;
+    }
+
+    public async Task<IEnumerable<GetAllQuestionResponse>> Handle(GetExamQuestionsRequest request, CancellationToken cancellationToken)
+    {
+        var questions = await _questionRepository.GetAll(cancellationToken);
+        
+        // Получаем список из 30 случайных вопросов
+        var randomQuestions = questions
+            .OrderBy(q => new Random().Next())
+            .Take(30);
+
+        return _mapper.Map<IEnumerable<GetAllQuestionResponse>>(randomQuestions);
+    }
+}

--- a/PDD.NET_Api/PDD.NET.QuestionAnswer/PDD.NET.Application/Features/Questions/Queries/GetExamQuestions/GetExamQuestionsRequest.cs
+++ b/PDD.NET_Api/PDD.NET.QuestionAnswer/PDD.NET.Application/Features/Questions/Queries/GetExamQuestions/GetExamQuestionsRequest.cs
@@ -1,0 +1,6 @@
+using MediatR;
+using PDD.NET.Application.Features.Questions.Queries.GetAllQuestions;
+
+namespace PDD.NET.Application.Features.Questions.Queries.GetExamQuestions;
+
+public sealed record GetExamQuestionsRequest() : IRequest<IEnumerable<GetAllQuestionResponse>>;

--- a/PDD.NET_Api/PDD.NET.QuestionAnswer/PDD.NET.Persistence/FakeDataFactory.cs
+++ b/PDD.NET_Api/PDD.NET.QuestionAnswer/PDD.NET.Persistence/FakeDataFactory.cs
@@ -11,7 +11,8 @@ public static class FakeDataFactory
         new QuestionCategory() { Id = 3, Text = "Дорожная разметка" },
         new QuestionCategory() { Id = 4, Text = "Специальные сигналы" },
         new QuestionCategory() { Id = 5, Text = "Светофор и Регулировщик" },
-        new QuestionCategory() { Id = 6, Text = "Начало движения, маневрирование" }
+        new QuestionCategory() { Id = 6, Text = "Начало движения, маневрирование" },
+        new QuestionCategory() { Id = 7, Text = "Скорость движения" }
     };
 
     public static IEnumerable<Question> Questions => new List<Question>()
@@ -57,11 +58,18 @@ public static class FakeDataFactory
         new Question() { Id = 28, CategoryId = 6, ImageData = "https://storage.yandexcloud.net/pddlife/abm/n26_8.jpg", Text = "В каких направлениях Вам можно продолжить движение по второй полосе?" },
         new Question() { Id = 29, CategoryId = 6, ImageData = "https://storage.yandexcloud.net/pddlife/abm/n6_7.jpg", Text = "Вы намерены продолжить движение по главной дороге. Обязаны ли Вы включить указатели левого поворота?" },
         new Question() { Id = 30, CategoryId = 6, ImageData = "https://storage.yandexcloud.net/pddlife/abm/n28_9.jpg", Text = "Разрешено ли водителю движение задним ходом для посадки пассажира на этом участке дороги?" },
+        
+        // Скорость движения
+        new Question() { Id = 31, CategoryId = 7, ImageData = "https://storage.yandexcloud.net/pddlife/abm/n35_10.jpg", Text = "С какой максимальной скоростью Вы имеете право продолжить движение на грузовом автомобиле с разрешенной максимальной массой не более 3,5 т после въезда на примыкающую слева дорогу?" },
+        new Question() { Id = 32, CategoryId = 7, ImageData = "https://storage.yandexcloud.net/pddlife/abm/n6_10.jpg", Text = "С какой максимальной скоростью Вы имеете право продолжить движение на легковом автомобиле?" },
+        new Question() { Id = 33, CategoryId = 7, ImageData = "https://storage.yandexcloud.net/pddlife/abm/n16_4.jpg", Text = "О чем информируют эти знаки?" },
+        new Question() { Id = 34, CategoryId = 7, ImageData = "https://storage.yandexcloud.net/pddlife/abm/n16_10.jpg", Text = "С какой максимальной скоростью Вы имеете право продолжить движение вне населенных пунктов на легковом автомобиле?" },
+        new Question() { Id = 35, CategoryId = 7, ImageData = "https://storage.yandexcloud.net/pddlife/abm/n15_3.jpg", Text = "Этот дорожный знак:" },
     };
 
     public static IEnumerable<AnswerOption> AnswerOptions => new List<AnswerOption>()
     {
-        
+        // Общие положения
         new AnswerOption() { Id = 3, QuestionId = 1, Text = "Автобусы (в том числе школьные).", IsRight = false },
         new AnswerOption() { Id = 4, QuestionId = 1, Text = "Автобусы, троллейбусы, трамваи, используемые при осуществлении регулярных перевозок пассажиров и багажа, движущиеся по установленному маршруту с обозначенными местами остановок.", IsRight = true },
         new AnswerOption() { Id = 5, QuestionId = 1, Text = "Любые транспортные средства, перевозящие пассажиров и багаж, движущиеся по маршруту с остановками.", IsRight = false },
@@ -188,5 +196,26 @@ public static class FakeDataFactory
         new AnswerOption() { Id = 92, QuestionId = 30, Text = "Разрешено только для посадки и высадки пассажиров.", IsRight = false },
         new AnswerOption() { Id = 93, QuestionId = 30, Text = "Запрещено в любом случае.", IsRight = false },
         new AnswerOption() { Id = 94, QuestionId = 30, Text = "Разрешено, если это не мешает движению других транспортных средств.", IsRight = true },
+        
+        // Скорость движения
+        new AnswerOption() { Id = 95, QuestionId = 31, Text = "60 км/ч.", IsRight = true },
+        new AnswerOption() { Id = 96, QuestionId = 31, Text = "70 км/ч.", IsRight = false },
+        new AnswerOption() { Id = 97, QuestionId = 31, Text = "90 км/ч.", IsRight = false },
+
+        new AnswerOption() { Id = 98, QuestionId = 32, Text = "70 км/ч.", IsRight = false },
+        new AnswerOption() { Id = 99, QuestionId = 32, Text = "90 км/ч.", IsRight = false },
+        new AnswerOption() { Id = 100, QuestionId = 32, Text = "110 км/ч.", IsRight = true },
+
+        new AnswerOption() { Id = 101, QuestionId = 33, Text = "Разрешенная скорость не более 40 км/ч при влажном покрытии.", IsRight = false },
+        new AnswerOption() { Id = 102, QuestionId = 33, Text = "Рекомендуемая скорость 40 км/ч при влажном покрытии.", IsRight = true },
+        new AnswerOption() { Id = 103, QuestionId = 33, Text = "Рекомендуемая скорость не более 40 км/ч только во время дождя.", IsRight = false },
+
+        new AnswerOption() { Id = 104, QuestionId = 34, Text = "60 км/ч.", IsRight = false },
+        new AnswerOption() { Id = 105, QuestionId = 34, Text = "90 км/ч.", IsRight = true },
+        new AnswerOption() { Id = 106, QuestionId = 34, Text = "110 км/ч.", IsRight = false },
+
+        new AnswerOption() { Id = 107, QuestionId = 35, Text = "Рекомендует двигаться со скоростью 40 км/ч.", IsRight = false },
+        new AnswerOption() { Id = 108, QuestionId = 35, Text = "Требует двигаться со скоростью не менее 40 км/ч.", IsRight = false },
+        new AnswerOption() { Id = 109, QuestionId = 35, Text = "Запрещает движение со скоростью более 40 км/ч.", IsRight = true },
     };
 }

--- a/PDD.NET_Api/PDD.NET.QuestionAnswer/PDD.NET.WebApi/Controllers/QuestionsController.cs
+++ b/PDD.NET_Api/PDD.NET.QuestionAnswer/PDD.NET.WebApi/Controllers/QuestionsController.cs
@@ -4,6 +4,7 @@ using PDD.NET.Application.Features.Questions.Commands.CreateQuestion;
 using PDD.NET.Application.Features.Questions.Commands.DeleteQuestion;
 using PDD.NET.Application.Features.Questions.Commands.UpdateQuestion;
 using PDD.NET.Application.Features.Questions.Queries.GetAllQuestions;
+using PDD.NET.Application.Features.Questions.Queries.GetExamQuestions;
 using PDD.NET.Application.Features.Questions.Queries.GetQuestionById;
 using PDD.NET.Application.Features.Questions.Queries.GetQuestionsByCategoryId;
 
@@ -29,6 +30,18 @@ namespace PDD.NET.WebApi.Controllers
         public async Task<ActionResult<IEnumerable<GetAllQuestionResponse>>> GetAllQuestions(CancellationToken cancellationToken)
         {
             var questions = await _mediator.Send(new GetAllQuestionRequest(), cancellationToken);
+            return Ok(questions);
+        }
+        
+        /// <summary>
+        /// Получить вопросы для экзамена c вариантами ответов
+        /// </summary>
+        /// <param name="cancellationToken"></param>
+        /// <returns>Список вопросов для экзамена c вариантами ответов</returns>
+        [HttpGet("exam")]
+        public async Task<ActionResult<IEnumerable<GetAllQuestionResponse>>> GetExamQuestions(CancellationToken cancellationToken)
+        {
+            var questions = await _mediator.Send(new GetExamQuestionsRequest(), cancellationToken);
             return Ok(questions);
         }
 


### PR DESCRIPTION
Добавлена возможность получать 30 случайных вопросов для экзамена.
Реализовано отображение дополнительных вопросов, при неправильных ответах.
Отображение результатов экзамена.
Передача информации о результате прохождения экзамена.